### PR TITLE
Added padding so image-manager is not located too close against the sidebar edges

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -1,3 +1,7 @@
+#app {
+  padding: 15px;
+}
+
 #image-drop-zone {
   position: relative;
   width: 100%;


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#3647

## Description
Added padding property to image-manager.

## Screenshots/screencasts
<img width="1137" alt="Slider demo" src="https://user-images.githubusercontent.com/52824207/63278463-f828ce80-c2af-11e9-9efe-7264ecfce181.png">


## Backward compatibility
This change is fully backward compatible.